### PR TITLE
Multiple owls

### DIFF
--- a/GameEngine/CardType.cs
+++ b/GameEngine/CardType.cs
@@ -11,4 +11,27 @@ namespace GameEngine
         Purple,
         Sun
     }
+
+    static class CardTypeExtensions
+    {
+        public static BoardPositionType AsBoardPositionType(this CardType cardType)
+        {
+            switch (cardType)
+            {
+                case CardType.Red:
+                    return BoardPositionType.Red;
+                case CardType.Orange:
+                    return BoardPositionType.Orange;
+                case CardType.Yellow:
+                    return BoardPositionType.Yellow;
+                case CardType.Green:
+                    return BoardPositionType.Green;
+                case CardType.Blue:
+                    return BoardPositionType.Blue;
+                case CardType.Purple:
+                    return BoardPositionType.Purple;
+            }
+            throw new InvalidMoveException("Sun is not a valid movement type");
+        }
+    }
 }

--- a/GameEngine/GameBoard.cs
+++ b/GameEngine/GameBoard.cs
@@ -8,39 +8,34 @@ namespace GameEngine
     { 
         public List<BoardPositionType> Board { get; private set; }
         public List<int> OwlPositions { get; set; }
-
-
-        public GameBoard(int gameSizeMultiplier)
+        
+        public int NestPosition
+        {
+            get { return Board.Count - 1; }
+        }
+        
+        public GameBoard(int gameSizeMultiplier, int numberOfOwls = 6)
         {
             BuildBoard(gameSizeMultiplier);
-            OwlPositions = Enumerable.Repeat(0, gameSizeMultiplier).ToList();
+            OwlPositions = Enumerable.Repeat(0, numberOfOwls).ToList();
         }
 
-        public void Move(CardType type, int owlIndex)
+        public void Move(Play play)
         {
-            if (OwlPositions[owlIndex] == Board.Count - 1)
-            {
-                throw new InvalidMoveException("Owl is already in the Nest");
-            }
-            if(type == CardType.Sun)
+            if (play.Card == CardType.Sun)
             {
                 throw new InvalidMoveException("Sun is not a valid movement type");
             }
 
-            var targetBoardPosition = Convert(type);
-            for (int i = OwlPositions[owlIndex] + 1; i < Board.Count; i++)
-            {
-                if(Board[i] == targetBoardPosition || Board[i] == BoardPositionType.Nest)
-                {
-                    OwlPositions[owlIndex] = i;
-                    break;
-                }
-            }
+            var owlToMove = FindOwl(play.Position);
+            var newPosition = FindDestinationPosition(play);
+
+            OwlPositions[owlToMove] = newPosition;
         }
 
         private BoardPositionType Convert(CardType cardType)
         {
-            switch(cardType)
+            switch (cardType)
             {
                 case CardType.Red:
                     return BoardPositionType.Red;
@@ -56,6 +51,30 @@ namespace GameEngine
                     return BoardPositionType.Purple;
             }
             return BoardPositionType.Nest;
+        }
+
+        private int FindOwl(int position)
+        {
+            var owlIndex = OwlPositions.IndexOf(position);
+            if (owlIndex == -1) {
+                throw new InvalidMoveException("There is no owl at position " + position);
+            }
+            return owlIndex;
+        }
+
+        private int FindDestinationPosition(Play play)
+        {
+            var desiredBoardColor = Convert(play.Card);
+            int newPosition;
+            for (newPosition = play.Position + 1; newPosition < NestPosition; ++newPosition)
+            {
+                var newPositionColor = Board[newPosition];
+                if (newPositionColor == desiredBoardColor)
+                {
+                    break;
+                }
+            }
+            return newPosition;
         }
 
         private void BuildBoard(int gameSizeMultiplier)

--- a/GameEngine/GameBoard.cs
+++ b/GameEngine/GameBoard.cs
@@ -65,15 +65,14 @@ namespace GameEngine
         private int FindDestinationPosition(Play play)
         {
             var desiredBoardColor = Convert(play.Card);
-            int newPosition;
-            for (newPosition = play.Position + 1; newPosition < NestPosition; ++newPosition)
+            int newPosition = play.Position;
+            Predicate<int> isEmptySpaceOfCorrectColor = (position) =>
+                desiredBoardColor == Board[position]
+                    && !OwlPositions.Contains(position);
+            do
             {
-                var newPositionColor = Board[newPosition];
-                if (newPositionColor == desiredBoardColor)
-                {
-                    break;
-                }
-            }
+                newPosition += 1;
+            } while (newPosition < NestPosition && !isEmptySpaceOfCorrectColor(newPosition));
             return newPosition;
         }
 

--- a/GameEngine/GameBoard.cs
+++ b/GameEngine/GameBoard.cs
@@ -1,23 +1,24 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace GameEngine
 {
     public class GameBoard
     { 
         public List<BoardPositionType> Board { get; private set; }
-        public int OwlPosition { get; set; }
+        public List<int> OwlPositions { get; set; }
 
 
         public GameBoard(int gameSizeMultiplier)
         {
             BuildBoard(gameSizeMultiplier);
-            OwlPosition = 0;
+            OwlPositions = Enumerable.Repeat(0, gameSizeMultiplier).ToList();
         }
 
-        public void Move(CardType type)
+        public void Move(CardType type, int owlIndex)
         {
-            if(OwlPosition == Board.Count - 1)
+            if (OwlPositions[owlIndex] == Board.Count - 1)
             {
                 throw new InvalidMoveException("Owl is already in the Nest");
             }
@@ -27,11 +28,11 @@ namespace GameEngine
             }
 
             var targetBoardPosition = Convert(type);
-            for (int i = OwlPosition + 1; i < Board.Count; i++)
+            for (int i = OwlPositions[owlIndex] + 1; i < Board.Count; i++)
             {
                 if(Board[i] == targetBoardPosition || Board[i] == BoardPositionType.Nest)
                 {
-                    OwlPosition = i;
+                    OwlPositions[owlIndex] = i;
                     break;
                 }
             }
@@ -59,17 +60,14 @@ namespace GameEngine
 
         private void BuildBoard(int gameSizeMultiplier)
         {
+            var nonNestTypes = Enum.GetValues(typeof(BoardPositionType))
+                .Cast<BoardPositionType>()
+                .Where(b => b != BoardPositionType.Nest);
+
             Board = new List<BoardPositionType>();
             for (int i = 0; i < gameSizeMultiplier; i++)
             {
-                foreach (BoardPositionType type in Enum.GetValues(typeof(BoardPositionType)))
-                {
-                    if (type == BoardPositionType.Nest)
-                    {
-                        continue;
-                    }
-                    Board.Add(type);
-                }
+                Board.AddRange(nonNestTypes);
             }
             Board.Add(BoardPositionType.Nest);
         }

--- a/GameEngine/GameState.cs
+++ b/GameEngine/GameState.cs
@@ -39,7 +39,7 @@ namespace GameEngine
             else
             {
                 var play = Player.FormulatePlay(Board);
-                Console.WriteLine("Player chose to play a {0} card on an owl at position {1}", play.Card, play.Position);
+                Console.WriteLine("Player chose to play {0}", play);
                 Board.Move(play);
                 Player.Discard(play.Card);
             }
@@ -50,8 +50,7 @@ namespace GameEngine
 
         public bool GameIsWon()
         {
-            return Board.OwlPositions
-                .TrueForAll(position => position == Board.NestPosition);
+            return Board.Owls.AreAllNested;
         }
 
         public bool GameIsLost()

--- a/GameEngine/GameState.cs
+++ b/GameEngine/GameState.cs
@@ -11,7 +11,7 @@ namespace GameEngine
         public IPlayer Player { get; private set; }
         public int SunCounter { get; private set; }
         public int GameSizeMultiplier { get; }
-
+        
         public GameState(IPlayer player, Deck deck, int gameSizeMultiplier)
         {
             Board = new GameBoard(gameSizeMultiplier);
@@ -38,10 +38,10 @@ namespace GameEngine
             }
             else
             {
-                var cardToPlay = Player.SelectCardToPlay(Board);
-                Console.WriteLine("Player chose to play a {0} card", cardToPlay);
-                Board.Move(cardToPlay);
-                Player.Discard(cardToPlay);
+                var play = Player.FormulatePlay(Board);
+                Console.WriteLine("Player chose to play a {0} card on an owl at position {1}", play.Card, play.Position);
+                Board.Move(play);
+                Player.Discard(play.Card);
             }
             var newCards = Deck.Draw(1);
             Console.WriteLine("Player drew a {0} card", newCards[0]);
@@ -50,7 +50,8 @@ namespace GameEngine
 
         public bool GameIsWon()
         {
-            return Board.OwlPosition == Board.Board.Count - 1;
+            return Board.OwlPositions
+                .TrueForAll(position => position == Board.NestPosition);
         }
 
         public bool GameIsLost()

--- a/GameEngine/Parliament.cs
+++ b/GameEngine/Parliament.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace GameEngine
+{
+    // "Parliament" is the collective noun for a group of owls.
+    public class Parliament
+    {
+        private HashSet<int> PositionsWithOwls { get; set; }
+
+        public int Count { get; private set; }
+        public int InTheNest { get; private set; }
+
+        public bool AreAllNested { get { return Count == InTheNest; } }
+        public int LeadOwl { get { return PositionsWithOwls.Max(); } }
+        public int TrailingOwl { get { return PositionsWithOwls.Min(); } }
+
+        public Parliament(int numberOfOwls)
+        {
+            PositionsWithOwls = new HashSet<int>(
+                Enumerable.Range(0, numberOfOwls)
+            );
+            Count = numberOfOwls;
+            InTheNest = 0;
+        }
+
+        public bool Inhabit(int position)
+        {
+            return PositionsWithOwls.Contains(position);
+        }
+
+        public void Move(int from, int to)
+        {
+            TakeOff(from);
+            PositionsWithOwls.Add(to);
+        }
+
+        public void Nest(int from)
+        {
+            TakeOff(from);
+            InTheNest++;
+        }
+
+        private void TakeOff(int from)
+        {
+            bool owlWasPresent = PositionsWithOwls.Remove(from);
+            if (!owlWasPresent)
+            {
+                throw new InvalidMoveException("There is no owl at position " + from);
+            }
+        }
+    }
+}

--- a/GameEngine/Play.cs
+++ b/GameEngine/Play.cs
@@ -1,0 +1,14 @@
+﻿namespace GameEngine
+{
+    public class Play
+    {
+        public CardType Card { get; }
+        public int Position { get; }
+
+        public Play(CardType card, int position)
+        {
+            Card = card;
+            Position = position;
+        }
+    }
+}

--- a/GameEngine/Play.cs
+++ b/GameEngine/Play.cs
@@ -10,5 +10,10 @@
             Card = card;
             Position = position;
         }
+
+        public override string ToString()
+        {
+            return string.Format("a {0} card on the owl at position {1}", Card, Position);
+        }
     }
 }

--- a/GameEngine/Players/IPlayer.cs
+++ b/GameEngine/Players/IPlayer.cs
@@ -8,7 +8,7 @@ namespace GameEngine.Players
 
         void AddCardsToHand(List<CardType> cards);
         void Discard(CardType card);
-        CardType SelectCardToPlay(GameBoard board);
+        Play FormulatePlay(GameBoard board);
         bool HandContainsSun();
     }
 }

--- a/GameEngine/Players/LeastRecentCardPlayer.cs
+++ b/GameEngine/Players/LeastRecentCardPlayer.cs
@@ -2,9 +2,17 @@
 {
     public class LeastRecentCardPlayer : Player
     {
-        public override CardType SelectCardToPlay(GameBoard board)
+        private CardType OldestCard
         {
-            return Hand[0];
+            get { return Hand[0]; }
+        }
+
+        public override Play FormulatePlay(GameBoard board)
+        {
+            return new Play(
+                OldestCard,
+                PositionOfTryHardOwl(board)
+            );
         }
     }
 }

--- a/GameEngine/Players/LeastRecentCardPlayer.cs
+++ b/GameEngine/Players/LeastRecentCardPlayer.cs
@@ -11,7 +11,7 @@
         {
             return new Play(
                 OldestCard,
-                PositionOfTryHardOwl(board)
+                board.Owls.LeadOwl
             );
         }
     }

--- a/GameEngine/Players/Player.cs
+++ b/GameEngine/Players/Player.cs
@@ -28,18 +28,5 @@ namespace GameEngine.Players
         }
 
         public abstract Play FormulatePlay(GameBoard board);
-
-        protected int PositionOfStragglerOwl(GameBoard board)
-        {
-            return board.OwlPositions
-                .Where(position => position < board.NestPosition)
-                .Min();
-        }
-        protected int PositionOfTryHardOwl(GameBoard board)
-        {
-            return board.OwlPositions
-                .Where(position => position < board.NestPosition)
-                .Max();
-        }
     }
 }

--- a/GameEngine/Players/Player.cs
+++ b/GameEngine/Players/Player.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace GameEngine.Players
 {
@@ -21,11 +22,24 @@ namespace GameEngine.Players
             Hand.Remove(card);
         }
 
-        public abstract CardType SelectCardToPlay(GameBoard board);
-
         public bool HandContainsSun()
         {
             return Hand.Contains(CardType.Sun);
+        }
+
+        public abstract Play FormulatePlay(GameBoard board);
+
+        protected int PositionOfStragglerOwl(GameBoard board)
+        {
+            return board.OwlPositions
+                .Where(position => position < board.NestPosition)
+                .Min();
+        }
+        protected int PositionOfTryHardOwl(GameBoard board)
+        {
+            return board.OwlPositions
+                .Where(position => position < board.NestPosition)
+                .Max();
         }
     }
 }

--- a/GameEngine/Players/RandomPlayer.cs
+++ b/GameEngine/Players/RandomPlayer.cs
@@ -15,7 +15,7 @@ namespace GameEngine.Players
         {
             return new Play(
                 RandomCard,
-                PositionOfStragglerOwl(board)
+                board.Owls.TrailingOwl
             );
         }
     }

--- a/GameEngine/Players/RandomPlayer.cs
+++ b/GameEngine/Players/RandomPlayer.cs
@@ -6,10 +6,17 @@ namespace GameEngine.Players
     {
         private static readonly Random Random = new Random();
 
-        public override CardType SelectCardToPlay(GameBoard board)
+        private CardType RandomCard
         {
-            int index = Random.Next(0, Hand.Count);
-            return Hand[index];
+            get { return Hand[Random.Next(0, Hand.Count)]; }
+        }
+
+        public override Play FormulatePlay(GameBoard board)
+        {
+            return new Play(
+                RandomCard,
+                PositionOfStragglerOwl(board)
+            );
         }
     }
 }

--- a/GameEngineTests/GameBoardTests.cs
+++ b/GameEngineTests/GameBoardTests.cs
@@ -99,6 +99,38 @@ namespace GameEngineTests
             Assert.AreEqual(expectedNumberOfOwls, actualOwls);
         }
 
+        [TestMethod]
+        public void ShouldHootAnOwlToEmptyColoredSpace()
+        {
+            var board = new GameBoard(2, 2);
+
+            board.Move(new Play(CardType.Orange, 0));
+
+            CollectionAssert.AreEquivalent(new[] { 0, 1 }, board.OwlPositions);
+
+            board.Move(new Play(CardType.Orange, 0));
+
+            CollectionAssert.AreEquivalent(new[] { 1, 7 }, board.OwlPositions);
+        }
+
+        [TestMethod]
+        public void ShouldHootAnOwlToNest()
+        {
+            var board = new GameBoard(2, 2);
+
+            board.Move(new Play(CardType.Orange, 0));
+
+            CollectionAssert.AreEquivalent(new[] { 0, 1 }, board.OwlPositions);
+
+            board.Move(new Play(CardType.Orange, 0));
+
+            CollectionAssert.AreEquivalent(new[] { 1, 7 }, board.OwlPositions);
+
+            board.Move(new Play(CardType.Orange, 1));
+
+            CollectionAssert.AreEquivalent(new[] { 7, board.NestPosition }, board.OwlPositions);
+        }
+
         #endregion
     }
 }

--- a/GameEngineTests/GameBoardTests.cs
+++ b/GameEngineTests/GameBoardTests.cs
@@ -6,14 +6,14 @@ namespace GameEngineTests
     [TestClass]
     public class GameBoardTests
     {
-        [TestMethod]
-        public void ShouldStartOwlsAtFirstSpots()
-        {
-            var board = new GameBoard(2);
-            var actualPosition = board.OwlPosition;
-            var expectedPosition = 0;
+        #region Single-owl tests
 
-            Assert.AreEqual(expectedPosition, actualPosition);
+        [TestMethod]
+        public void ShouldStartOwlAtFirstSpot()
+        {
+            var board = new GameBoard(2, 1);
+            
+            Assert.AreEqual(0, board.OwlPositions[0]);
         }
 
         [TestMethod]
@@ -25,41 +25,80 @@ namespace GameEngineTests
         [DataRow(CardType.Purple, 5)]
         public void ShouldMakeSimpleMoves(CardType cardType, int newPosition)
         {
-            var board = new GameBoard(2);
+            var board = new GameBoard(2, 1);
+            var play = new Play(cardType, 0);
 
-            board.Move(cardType);
+            board.Move(play);
 
-            Assert.AreEqual(newPosition, board.OwlPosition);
+            Assert.AreEqual(newPosition, board.OwlPositions[0]);
         }
 
         [TestMethod]
         public void ShouldMoveOwlIntoNest()
         {
-            var board = new GameBoard(2);
-            board.OwlPosition = board.Board.Count - 2;
+            var board = new GameBoard(2, 1);
+            var initialPosition = board.Board.Count - 2;
+            board.OwlPositions[0] = initialPosition;
+            var play = new Play(CardType.Red, initialPosition);
 
-            board.Move(CardType.Red);
+            board.Move(play);
 
-            Assert.AreEqual(board.Board.Count - 1, board.OwlPosition);
-            Assert.AreEqual(BoardPositionType.Nest, board.Board[board.OwlPosition]);
+            var newOwlPosition = board.OwlPositions[0];
+            Assert.AreEqual(board.NestPosition, newOwlPosition,
+                "Owl is not on last position.");
+            Assert.AreEqual(BoardPositionType.Nest, board.Board[newOwlPosition],
+                "Owl's position is not a nest.");
         }
 
         [TestMethod]
-        public void ShouldFailToMoveOwlWhenItIsAlreadyInTheNest()
+        public void ShouldFailToMoveWhenThereAreNoOwlsAtThePosition()
         {
-            var board = new GameBoard(2);
-            board.OwlPosition = board.Board.Count - 1;
+            var board = new GameBoard(2, 1);
+            var positionWithNoOwls = 1;
+            var play = new Play(CardType.Red, positionWithNoOwls);
 
-            Assert.ThrowsException<InvalidMoveException>(() => board.Move(CardType.Red));
+            Assert.ThrowsException<InvalidMoveException>(() =>
+                board.Move(play)
+            );
+
         }
 
         [TestMethod]
         public void ShouldFailToMoveWhenInvalidCardType()
         {
-            var board = new GameBoard(2);
-            board.OwlPosition = board.Board.Count - 1;
+            var board = new GameBoard(2, 1);
+            var play = new Play(CardType.Sun, 0);
 
-            Assert.ThrowsException<InvalidMoveException>(() => board.Move(CardType.Sun));
+            Assert.ThrowsException<InvalidMoveException>(() =>
+                board.Move(play)
+            );
         }
+
+        #endregion
+
+        #region Multi-owl tests
+
+        [TestMethod]
+        public void ShouldStartWithSixOwlsByDefault()
+        {
+            var board = new GameBoard(2);
+            var actualOwls = board.OwlPositions.Count;
+
+            Assert.AreEqual(6, actualOwls);
+        }
+
+        [TestMethod]
+        [DataRow(1)]
+        [DataRow(6)]
+        [DataRow(100)]
+        public void ShouldStartWithSpecificNumberOfOwls(int expectedNumberOfOwls)
+        {
+            var board = new GameBoard(2, expectedNumberOfOwls);
+            var actualOwls = board.OwlPositions.Count;
+
+            Assert.AreEqual(expectedNumberOfOwls, actualOwls);
+        }
+
+        #endregion
     }
 }

--- a/GameEngineTests/GameEngineTests.csproj
+++ b/GameEngineTests/GameEngineTests.csproj
@@ -57,6 +57,7 @@
     <Compile Include="DeckTests.cs" />
     <Compile Include="Players\LeastRecentCardPlayerTests.cs" />
     <Compile Include="GameEngineTests.cs" />
+    <Compile Include="TestUtilities.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/GameEngineTests/Players/LeastRecentCardPlayerTests.cs
+++ b/GameEngineTests/Players/LeastRecentCardPlayerTests.cs
@@ -18,12 +18,12 @@ namespace GameEngineTests.Players
             player.AddCardsToHand(hand);
             var board = new GameBoard(2);
 
-            var playedCard = player.SelectCardToPlay(board);
-            Assert.AreEqual(firstCard, playedCard);
+            var play = player.FormulatePlay(board);
+            Assert.AreEqual(firstCard, play.Card);
 
-            player.Discard(playedCard);
-            playedCard = player.SelectCardToPlay(board);
-            Assert.AreEqual(secondCard, playedCard);
+            player.Discard(play.Card);
+            play = player.FormulatePlay(board);
+            Assert.AreEqual(secondCard, play.Card);
         }
     }
 }

--- a/GameEngineTests/Players/PlayerTests.cs
+++ b/GameEngineTests/Players/PlayerTests.cs
@@ -48,7 +48,7 @@ namespace GameEngineTests.Players
 
     class DummyPlayer : Player
     {
-        public override CardType SelectCardToPlay(GameBoard board)
+        public override Play FormulatePlay(GameBoard board)
         {
             throw new NotImplementedException();
         }

--- a/GameEngineTests/Players/RandomPlayerTests.cs
+++ b/GameEngineTests/Players/RandomPlayerTests.cs
@@ -17,9 +17,10 @@ namespace GameEngineTests.Players
             player.AddCardsToHand(hand);
             var board = new GameBoard(2);
 
-            var playedCard = player.SelectCardToPlay(board);
+            var play = player.FormulatePlay(board);
 
-            Assert.AreEqual(expectedCardType, playedCard);
+            Assert.AreEqual(expectedCardType, play.Card);
+            Assert.AreEqual(0, play.Position);
         }
     }
 }

--- a/GameEngineTests/TestUtilities.cs
+++ b/GameEngineTests/TestUtilities.cs
@@ -1,0 +1,27 @@
+﻿using GameEngine;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace GameEngineTests
+{
+    public static class TestUtilities
+    {
+        public static void AssertOwlPositionsMatch(this GameBoard board, params int[] expectedPositions)
+        {
+            Assert.AreEqual(expectedPositions.Length, board.Owls.Count);
+            int expectedOwlsInNest = 0;
+            foreach (var expectedPosition in expectedPositions)
+            {
+                if (expectedPosition == board.NestPosition)
+                {
+                    expectedOwlsInNest++;
+                }
+                else
+                {
+                    Assert.IsTrue(board.Owls.Inhabit(expectedPosition),
+                        "No owl found at " + expectedPosition);
+                }
+            }
+            Assert.AreEqual(expectedOwlsInNest, board.Owls.InTheNest);
+        }
+    }
+}


### PR DESCRIPTION
This changeset enables multiple owl games as follows:

- default initialization of 6 owls
- optional initialization of a specific number of owls
- moves require an indication of which owl to move
- the Player classes pick which owl to move
- moves respect the "hoot" rule (jumping instead of sharing a space)
