### PR TITLE
GreatestDistanceSingleCardPlayer and various QoL refactors

### DIFF
--- a/GameEngine/CardType.cs
+++ b/GameEngine/CardType.cs
@@ -1,5 +1,4 @@
-﻿
-namespace GameEngine
+﻿namespace GameEngine
 {
     public enum CardType
     {

--- a/GameEngine/Deck.cs
+++ b/GameEngine/Deck.cs
@@ -14,11 +14,12 @@ namespace GameEngine
             Shuffle();
         }
 
-        public List<CardType> Draw(int numberOfDraws)
+        public CardType[] Draw(int numberDesired)
         {
-            var cards = Cards.GetRange(0, numberOfDraws);
-            Cards.RemoveRange(0, numberOfDraws);
-            return cards;
+            var numberToDraw = Math.Min(numberDesired, Cards.Count);
+            var cards = Cards.GetRange(0, numberToDraw);
+            Cards.RemoveRange(0, numberToDraw);
+            return cards.ToArray();
         }
 
         private void BuildDeck(int gameSizeMultiplier)

--- a/GameEngine/GameBoard.cs
+++ b/GameEngine/GameBoard.cs
@@ -23,7 +23,7 @@ namespace GameEngine
         public void Move(Play play)
         {
             var newPosition = FindDestinationPosition(play);
-            if(newPosition == NestPosition)
+            if(newPosition >= NestPosition)
             {
                 Owls.Nest(play.Position);
             } else
@@ -32,7 +32,7 @@ namespace GameEngine
             }
         }
 
-        private int FindDestinationPosition(Play play)
+        public int FindDestinationPosition(Play play)
         {
             var desiredColor = play.Card.AsBoardPositionType();
             int newPosition = play.Position + 1;
@@ -46,7 +46,7 @@ namespace GameEngine
 
         private bool OwlShouldStopHere(int position, BoardPositionType desiredColor)
         {
-            return position == NestPosition
+            return position >= NestPosition
                 || (desiredColor == Board[position] && !Owls.Inhabit(position));
         }
 

--- a/GameEngine/GameState.cs
+++ b/GameEngine/GameState.cs
@@ -44,8 +44,15 @@ namespace GameEngine
                 Player.Discard(play.Card);
             }
             var newCards = Deck.Draw(1);
-            Console.WriteLine("Player drew a {0} card", newCards[0]);
             Player.AddCardsToHand(newCards);
+            if (newCards.Length > 0)
+            {
+                Console.WriteLine("Player drew a {0} card", newCards[0]);
+            }
+            else
+            {
+                Console.WriteLine("Player drew no cards since the deck was empty");
+            }
         }
 
         public bool GameIsWon()

--- a/GameEngine/Parliament.cs
+++ b/GameEngine/Parliament.cs
@@ -11,6 +11,7 @@ namespace GameEngine
         public int Count { get; private set; }
         public int InTheNest { get; private set; }
 
+        public IEnumerable<int> ListOfPositions { get { return PositionsWithOwls; } }
         public bool AreAllNested { get { return Count == InTheNest; } }
         public int LeadOwl { get { return PositionsWithOwls.Max(); } }
         public int TrailingOwl { get { return PositionsWithOwls.Min(); } }

--- a/GameEngine/Players/GreatestDistanceSingleCardPlayer.cs
+++ b/GameEngine/Players/GreatestDistanceSingleCardPlayer.cs
@@ -1,0 +1,25 @@
+﻿namespace GameEngine.Players
+{
+    public class GreatestDistanceSingleCardPlayer : Player
+    {
+        public override Play FormulatePlay(GameBoard board)
+        {
+            Play greatestSingleDistancePlay = null;
+            int greatestDistance = 0;
+            foreach (var owlPosition in board.Owls.ListOfPositions) {
+                foreach (var card in Hand)
+                {
+                    var play = new Play(card, owlPosition);
+                    var newPosition = board.FindDestinationPosition(play);
+                    var distance = newPosition - owlPosition;
+                    if (distance > greatestDistance)
+                    {
+                        greatestDistance = distance;
+                        greatestSingleDistancePlay = play;
+                    }
+                }
+            }
+            return greatestSingleDistancePlay;
+        }
+    }
+}

--- a/GameEngine/Players/IPlayer.cs
+++ b/GameEngine/Players/IPlayer.cs
@@ -6,7 +6,7 @@ namespace GameEngine.Players
     {
         List<CardType> Hand { get; }
 
-        void AddCardsToHand(List<CardType> cards);
+        void AddCardsToHand(params CardType[] cards);
         void Discard(CardType card);
         Play FormulatePlay(GameBoard board);
         bool HandContainsSun();

--- a/GameEngine/Players/Player.cs
+++ b/GameEngine/Players/Player.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 
 namespace GameEngine.Players
 {
@@ -12,7 +11,7 @@ namespace GameEngine.Players
             Hand = new List<CardType>();
         }
 
-        public void AddCardsToHand(List<CardType> cards)
+        public void AddCardsToHand(params CardType[] cards)
         {
             Hand.AddRange(cards);
         }

--- a/GameEngineTests/DeckTests.cs
+++ b/GameEngineTests/DeckTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using GameEngine;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -28,6 +29,18 @@ namespace GameEngineTests
 
             var deckSizeAfter = deck.Cards.Count;
             Assert.AreEqual(deckSizeBefore - 3, deckSizeAfter);
+        }
+
+        [TestMethod]
+        public void ShouldDrawFewerWhenDrawingTooMany()
+        {
+            var deck = new Deck(2);
+            deck.Draw(deck.Cards.Count - 1);
+            var theRestOfTheDeck = new List<CardType>(deck.Cards);
+
+            var actualCardsDrawn = deck.Draw(1000);
+
+            CollectionAssert.AreEqual(theRestOfTheDeck, actualCardsDrawn);
         }
     }
 }

--- a/GameEngineTests/GameEngineTests.csproj
+++ b/GameEngineTests/GameEngineTests.csproj
@@ -50,6 +50,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="GameBoardTests.cs" />
+    <Compile Include="Players\GreatestDistanceSingleCardPlayerTests.cs" />
     <Compile Include="Players\PlayerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Players\RandomPlayerTests.cs" />

--- a/GameEngineTests/GameStateTests.cs
+++ b/GameEngineTests/GameStateTests.cs
@@ -89,28 +89,32 @@ namespace GameEngineTests
         [TestMethod]
         public void ShouldWinGameWhenOwlsReachNest()
         {
-            var redCards = Enumerable.Repeat(CardType.Red, Multiplier * NumberOfOwls);
+            var redCards = Enumerable.Repeat(CardType.Red, Multiplier * NumberOfOwls + 3);
             Deck.Cards.InsertRange(0, redCards);
             State.StartGame();
 
-            foreach (int expectedNestedOwls in Enumerable.Range(0, NumberOfOwls))
+            foreach (int expectedOwlsInTheNest in Enumerable.Range(0, NumberOfOwls))
             {
-                var owlsStillInStartingPositions = Enumerable.Range(0, NumberOfOwls - expectedNestedOwls).ToArray();
+                var owlsInStartingPositionsOrNest = Enumerable.Range(0, NumberOfOwls - expectedOwlsInTheNest)
+                    .Concat(Enumerable.Repeat(State.Board.NestPosition, State.Board.Owls.InTheNest))
+                    .ToArray();
 
-                State.Board.AssertOwlPositionsMatch(owlsStillInStartingPositions);
-                Assert.AreEqual(expectedNestedOwls, State.Board.Owls.InTheNest);
+                State.Board.AssertOwlPositionsMatch(owlsInStartingPositionsOrNest);
+                Assert.AreEqual(expectedOwlsInTheNest, State.Board.Owls.InTheNest);
                 Assert.IsFalse(State.GameIsWon());
 
-                foreach (int playsForThisOwl in Enumerable.Range(0, Multiplier))
+                foreach (int playNumber in Enumerable.Range(1, Multiplier))
                 {
                     Assert.AreEqual(CardType.Red, State.Player.Hand[0]);
 
                     State.TakeTurn();
                     
-                    int expectedOwlsAtStart = NumberOfOwls - expectedNestedOwls - 1;
-                    var expectedNewPosition = expectedNestedOwls + Multiplier * (playsForThisOwl + 1);
-                    var expectedPositions = Enumerable.Range(0, expectedOwlsAtStart)
-                        .Concat(new[] { expectedNewPosition })
+                    var expectedOwlsAtStart = Enumerable.Range(0, NumberOfOwls - expectedOwlsInTheNest - 1);
+                    var expectedNewPosition = Multiplier * playNumber;
+                    var expectedNestedOwls = Enumerable.Repeat(State.Board.NestPosition, expectedOwlsInTheNest);
+                    var expectedPositions = expectedOwlsAtStart
+                        .Append(expectedNewPosition)
+                        .Concat(expectedNestedOwls)
                         .ToArray();
                     State.Board.AssertOwlPositionsMatch(expectedPositions);
                 }

--- a/GameEngineTests/Players/GreatestDistanceSingleCardPlayerTests.cs
+++ b/GameEngineTests/Players/GreatestDistanceSingleCardPlayerTests.cs
@@ -1,0 +1,48 @@
+﻿using System.Linq;
+using GameEngine;
+using GameEngine.Players;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace GameEngineTests.Players
+{
+    [TestClass]
+    public class GreatestDistanceSingleCardPlayerTests
+    {
+        private CardType[] OneCardOfEachColor
+        {
+            get
+            {
+                return new Deck(1).Cards
+                    .Where(card => card != CardType.Sun)
+                    .ToArray();
+            }
+        }
+
+        [TestMethod]
+        public void ShouldPlayCardOnOnlyOwlThatGoesFurthest()
+        {
+            var player = new GreatestDistanceSingleCardPlayer();
+            var board = new GameBoard(2, 1);
+            player.AddCardsToHand(OneCardOfEachColor);
+
+            var play = player.FormulatePlay(board);
+
+            Assert.AreEqual(CardType.Red, play.Card);
+            Assert.AreEqual(0, play.Position);
+        }
+
+        [TestMethod]
+        public void ShouldPlayCardOnOwlThatGoesFurthestWithHootingIntoNest()
+        {
+            var player = new GreatestDistanceSingleCardPlayer();
+            var board = new GameBoard(2);
+            board.Owls.Move(0, 6);
+            player.AddCardsToHand(OneCardOfEachColor);
+
+            var play = player.FormulatePlay(board);
+
+            Assert.AreEqual(CardType.Red, play.Card);
+            Assert.AreEqual(1, play.Position);
+        }
+    }
+}

--- a/GameEngineTests/Players/LeastRecentCardPlayerTests.cs
+++ b/GameEngineTests/Players/LeastRecentCardPlayerTests.cs
@@ -13,9 +13,8 @@ namespace GameEngineTests.Players
         {
             var firstCard = CardType.Red;
             var secondCard = CardType.Orange;
-            var hand = new List<CardType> { firstCard, secondCard };
             var player = new LeastRecentCardPlayer();
-            player.AddCardsToHand(hand);
+            player.AddCardsToHand(firstCard, secondCard);
             var board = new GameBoard(2);
 
             var play = player.FormulatePlay(board);

--- a/GameEngineTests/Players/PlayerTests.cs
+++ b/GameEngineTests/Players/PlayerTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using GameEngine;
 using GameEngine.Players;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -13,12 +12,10 @@ namespace GameEngineTests.Players
         [TestMethod]
         public void ShouldDiscard()
         {
-            var expectedCardType = CardType.Blue;
-            var hand = new List<CardType> { expectedCardType };
             var player = new DummyPlayer();
-            player.AddCardsToHand(hand);
+            player.AddCardsToHand(CardType.Blue);
 
-            player.Discard(expectedCardType);
+            player.Discard(CardType.Blue);
 
             Assert.AreEqual(0, player.Hand.Count);
         }
@@ -26,7 +23,7 @@ namespace GameEngineTests.Players
         [TestMethod]
         public void ShouldAddCardsToHand()
         {
-            var expectedHand = new List<CardType> { CardType.Blue };
+            var expectedHand = new [] { CardType.Blue };
             var player = new DummyPlayer();
 
             player.AddCardsToHand(expectedHand);
@@ -38,7 +35,7 @@ namespace GameEngineTests.Players
         public void ShouldDetectIfHandContainsSun()
         {
             var player = new DummyPlayer();
-            player.AddCardsToHand(new List<CardType> { CardType.Sun });
+            player.AddCardsToHand(CardType.Sun);
             Assert.IsTrue(player.HandContainsSun());
 
             player.Discard(CardType.Sun);

--- a/GameEngineTests/Players/RandomPlayerTests.cs
+++ b/GameEngineTests/Players/RandomPlayerTests.cs
@@ -11,15 +11,13 @@ namespace GameEngineTests.Players
         [TestMethod]
         public void ShouldPlayRandomCardFromHand()
         {
-            var expectedCardType = CardType.Blue;
-            var hand = new List<CardType> { expectedCardType };
             var player = new RandomPlayer();
-            player.AddCardsToHand(hand);
+            player.AddCardsToHand(CardType.Blue);
             var board = new GameBoard(2);
 
             var play = player.FormulatePlay(board);
 
-            Assert.AreEqual(expectedCardType, play.Card);
+            Assert.AreEqual(CardType.Blue, play.Card);
             Assert.AreEqual(0, play.Position);
         }
     }


### PR DESCRIPTION
- GreatestDistanceSingleCardPlayer makes whichever play results in the greatest distance moved by an owl. Order is not guaranteed if there is a tie.
- Deck.Draw returns no cards when the deck is empty since gameplay should continue until a win or lose condition is met. This was causing an intermittent failure of GameEngineTests.ShouldCompleteGame if one of the last few cards is a sun card.
- Hardened GameBoard.Move and GameBoard.FindDestinationPostion to prevent silly mistakes.
- GameBoard.FindDestinationPostion is public so that Player implementations don't have to duplicate code for look-ahead.
- IPlayer.AddCardsToHand's cards parameter is a params to make invokation nicer.
- GameStateTests.ShouldWinGameWhenOwlsReachNest has been refactored for clarity. It also adds 3 additional red cards to the deck since the player starts by drawing three. If they were (un?)lucky enough to draw a sun card within the last 3 cards, the test would fail. Yay, tests with randomness in them.