### PR TITLE
Game init config

### DIFF
--- a/GameEngine/CardType.cs
+++ b/GameEngine/CardType.cs
@@ -1,4 +1,8 @@
-﻿namespace GameEngine
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace GameEngine
 {
     public enum CardType
     {
@@ -11,8 +15,19 @@
         Sun
     }
 
-    static class CardTypeExtensions
+    public static class CardTypeExtensions
     {
+        public static CardType[] OneCardOfEachColor
+        {
+            get
+            {
+                return Enum.GetValues(typeof(CardType))
+                    .Cast<CardType>()
+                    .Where(card => card != CardType.Sun)
+                    .ToArray();
+            }
+        }
+
         public static BoardPositionType AsBoardPositionType(this CardType cardType)
         {
             switch (cardType)

--- a/GameEngine/Deck.cs
+++ b/GameEngine/Deck.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace GameEngine
 {
@@ -8,9 +9,10 @@ namespace GameEngine
         private static readonly Random Random = new Random();
         public List<CardType> Cards { get; private set; }
 
-        public Deck(int gameSizeMultiplier)
+        public Deck(int gameSizeMultiplier, int? numberOfSunCards = null)
         {
-            BuildDeck(gameSizeMultiplier);
+            var defaultSunCards = gameSizeMultiplier + 4 * gameSizeMultiplier / 3;
+            BuildDeck(gameSizeMultiplier, numberOfSunCards ?? defaultSunCards);
             Shuffle();
         }
 
@@ -22,16 +24,11 @@ namespace GameEngine
             return cards.ToArray();
         }
 
-        private void BuildDeck(int gameSizeMultiplier)
+        private void BuildDeck(int gameSizeMultiplier, int sunCards)
         {
-            Cards = new List<CardType>();
-            for (int i = 0; i < gameSizeMultiplier; i++)
-            {
-                foreach (CardType type in Enum.GetValues(typeof(CardType)))
-                {
-                    Cards.Add(type);
-                }
-            }
+            Cards = new List<CardType>(Enumerable.Repeat(0, gameSizeMultiplier)
+                .SelectMany(cards => CardTypeExtensions.OneCardOfEachColor)
+                .Concat(Enumerable.Repeat(CardType.Sun, sunCards)));
         }
 
         private void Shuffle()

--- a/GameEngine/GameEngine.cs
+++ b/GameEngine/GameEngine.cs
@@ -8,8 +8,7 @@ namespace GameEngine
         public void RunGame()
         {
             var player = new LeastRecentCardPlayer();
-            var deck = new Deck(10);
-            var state = new GameState(player, deck, 10);
+            var state = new GameState(10, player);
             state.StartGame();
             int numberOfTurns = 0;
             for (; ; numberOfTurns++)

--- a/GameEngine/GameOptions.cs
+++ b/GameEngine/GameOptions.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GameEngine
+{
+    public class GameOptions
+    {
+        public int ColoredCardsPerColor { get; private set; }
+        public int ColoredSpacesPerColor { get; private set; }
+        public int SunCards { get; private set; }
+        public int SunSpaces { get; private set; }
+        public int Owls { get; private set; }
+
+        public static GameOptions FromMultiplier(int gameSizeMultiplier)
+        {
+            return new GameOptions
+            {
+                ColoredCardsPerColor = gameSizeMultiplier,
+                ColoredSpacesPerColor = gameSizeMultiplier,
+                SunCards = gameSizeMultiplier,
+                SunSpaces = gameSizeMultiplier,
+                Owls = gameSizeMultiplier
+            };
+        }
+    }
+}

--- a/GameEngine/GameOptions.cs
+++ b/GameEngine/GameOptions.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace GameEngine
+﻿namespace GameEngine
 {
     public class GameOptions
     {
@@ -11,6 +7,8 @@ namespace GameEngine
         public int SunCards { get; private set; }
         public int SunSpaces { get; private set; }
         public int Owls { get; private set; }
+
+        private GameOptions() { }
 
         public static GameOptions FromMultiplier(int gameSizeMultiplier)
         {

--- a/GameEngine/GameState.cs
+++ b/GameEngine/GameState.cs
@@ -6,19 +6,22 @@ namespace GameEngine
 {
     public class GameState
     {
-        public GameBoard Board { get; private set; }
-        public Deck Deck { get; private set; }
-        public IPlayer Player { get; private set; }
+        public GameBoard Board { get; }
+        public Deck Deck { get; }
+        public IPlayer Player { get; }
+        public int SunSpaces { get; }
         public int SunCounter { get; private set; }
-        public int GameSizeMultiplier { get; }
-        
-        public GameState(IPlayer player, Deck deck, int gameSizeMultiplier)
+
+        public GameState(int multiplier, params IPlayer[] player)
+            : this(GameOptions.FromMultiplier(multiplier), player) { }
+
+        public GameState(GameOptions options, params IPlayer[] players)
         {
-            Board = new GameBoard(gameSizeMultiplier);
-            Deck = deck;
-            Player = player;
+            Board = new GameBoard(options.ColoredSpacesPerColor, options.Owls);
+            Deck = new Deck(options.ColoredCardsPerColor, options.SunCards);
+            Player = players[0];
+            SunSpaces = options.SunSpaces;
             SunCounter = 0;
-            GameSizeMultiplier = gameSizeMultiplier;
         }
 
         public void StartGame()
@@ -62,7 +65,7 @@ namespace GameEngine
 
         public bool GameIsLost()
         {
-            return SunCounter == GameSizeMultiplier;
+            return SunCounter == SunSpaces;
         }
     }
 }

--- a/GameEngine/GameState.cs
+++ b/GameEngine/GameState.cs
@@ -12,14 +12,14 @@ namespace GameEngine
         public int SunSpaces { get; }
         public int SunCounter { get; private set; }
 
-        public GameState(int multiplier, params IPlayer[] player)
+        public GameState(int multiplier, IPlayer player)
             : this(GameOptions.FromMultiplier(multiplier), player) { }
 
-        public GameState(GameOptions options, params IPlayer[] players)
+        public GameState(GameOptions options, IPlayer player)
         {
             Board = new GameBoard(options.ColoredSpacesPerColor, options.Owls);
             Deck = new Deck(options.ColoredCardsPerColor, options.SunCards);
-            Player = players[0];
+            Player = player;
             SunSpaces = options.SunSpaces;
             SunCounter = 0;
         }

--- a/GameEngineTests/DeckTests.cs
+++ b/GameEngineTests/DeckTests.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.Linq;
 using GameEngine;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -41,6 +41,38 @@ namespace GameEngineTests
             var actualCardsDrawn = deck.Draw(1000);
 
             CollectionAssert.AreEqual(theRestOfTheDeck, actualCardsDrawn);
+        }
+
+        [TestMethod]
+        public void ShouldDefaultTo28PercentSunCards()
+        {
+            var cards = new Deck(1).Cards;
+            Assert.AreEqual(8, cards.Count);
+            Assert.AreEqual(2, cards.Count(card => card == CardType.Sun));
+
+            cards = new Deck(6).Cards;
+            Assert.AreEqual(50, cards.Count);
+            Assert.AreEqual(14, cards.Count(card => card == CardType.Sun));
+
+            cards = new Deck(300).Cards;
+            Assert.AreEqual(2500, cards.Count);
+            Assert.AreEqual(700, cards.Count(card => card == CardType.Sun));
+        }
+
+        [TestMethod]
+        public void ShouldAcceptExplicitNumberOfSunCards()
+        {
+            var cards = new Deck(1, 0).Cards;
+            Assert.AreEqual(6, cards.Count);
+            CollectionAssert.DoesNotContain(cards, CardType.Sun);
+
+            cards = new Deck(6, 1).Cards;
+            Assert.AreEqual(37, cards.Count);
+            Assert.AreEqual(1, cards.Count(card => card == CardType.Sun));
+
+            cards = new Deck(300, 800).Cards;
+            Assert.AreEqual(2600, cards.Count);
+            Assert.AreEqual(800, cards.Count(card => card == CardType.Sun));
         }
     }
 }

--- a/GameEngineTests/GameStateTests.cs
+++ b/GameEngineTests/GameStateTests.cs
@@ -10,7 +10,6 @@ namespace GameEngineTests
     public class GameStateTests
     {
         private IPlayer Player;
-        private Deck Deck;
         private GameState State;
         private int Multiplier;
         private int NumberOfOwls;
@@ -21,7 +20,6 @@ namespace GameEngineTests
             Multiplier = 6;
             Player = new LeastRecentCardPlayer();
             State = new GameState(Multiplier, Player);
-            Deck = State.Deck;
             NumberOfOwls = State.Board.Owls.Count;
         }
 
@@ -40,7 +38,7 @@ namespace GameEngineTests
         [TestMethod]
         public void ShouldTakeOneTurnWithoutSunCard()
         {
-            Deck.Cards.InsertRange(0, new List<CardType> {
+            State.Deck.Cards.InsertRange(0, new List<CardType> {
                 CardType.Red,
                 CardType.Orange,
                 CardType.Yellow,
@@ -64,7 +62,7 @@ namespace GameEngineTests
         [TestMethod]
         public void ShouldPlaySunCardFirstWhenPossible()
         {
-            Deck.Cards.InsertRange(0, new List<CardType> {
+            State.Deck.Cards.InsertRange(0, new List<CardType> {
                 CardType.Orange,
                 CardType.Yellow,
                 CardType.Sun,
@@ -90,7 +88,7 @@ namespace GameEngineTests
         public void ShouldWinGameWhenOwlsReachNest()
         {
             var redCards = Enumerable.Repeat(CardType.Red, Multiplier * NumberOfOwls + 3);
-            Deck.Cards.InsertRange(0, redCards);
+            State.Deck.Cards.InsertRange(0, redCards);
             State.StartGame();
 
             foreach (int expectedOwlsInTheNest in Enumerable.Range(0, NumberOfOwls))
@@ -129,7 +127,7 @@ namespace GameEngineTests
         public void ShouldLoseGameWhenSunCounterReachesMaximum()
         {
             var cards = Enumerable.Repeat(CardType.Sun, Multiplier);
-            Deck.Cards.InsertRange(0, cards);
+            State.Deck.Cards.InsertRange(0, cards);
             State.StartGame();
 
             Assert.IsFalse(State.GameIsLost());

--- a/GameEngineTests/GameStateTests.cs
+++ b/GameEngineTests/GameStateTests.cs
@@ -18,11 +18,11 @@ namespace GameEngineTests
         [TestInitialize]
         public void TestInitialize()
         {
-            Player = new LeastRecentCardPlayer();
             Multiplier = 6;
-            NumberOfOwls = 6;
-            Deck = new Deck(Multiplier, 6);
-            State = new GameState(Player, Deck, Multiplier);
+            Player = new LeastRecentCardPlayer();
+            State = new GameState(Multiplier, Player);
+            Deck = State.Deck;
+            NumberOfOwls = State.Board.Owls.Count;
         }
 
         [TestMethod]

--- a/GameEngineTests/GameStateTests.cs
+++ b/GameEngineTests/GameStateTests.cs
@@ -21,7 +21,7 @@ namespace GameEngineTests
             Player = new LeastRecentCardPlayer();
             Multiplier = 6;
             NumberOfOwls = 6;
-            Deck = new Deck(Multiplier);
+            Deck = new Deck(Multiplier, 6);
             State = new GameState(Player, Deck, Multiplier);
         }
 

--- a/GameEngineTests/Players/GreatestDistanceSingleCardPlayerTests.cs
+++ b/GameEngineTests/Players/GreatestDistanceSingleCardPlayerTests.cs
@@ -8,22 +8,12 @@ namespace GameEngineTests.Players
     [TestClass]
     public class GreatestDistanceSingleCardPlayerTests
     {
-        private CardType[] OneCardOfEachColor
-        {
-            get
-            {
-                return new Deck(1).Cards
-                    .Where(card => card != CardType.Sun)
-                    .ToArray();
-            }
-        }
-
         [TestMethod]
         public void ShouldPlayCardOnOnlyOwlThatGoesFurthest()
         {
             var player = new GreatestDistanceSingleCardPlayer();
             var board = new GameBoard(2, 1);
-            player.AddCardsToHand(OneCardOfEachColor);
+            player.AddCardsToHand(CardTypeExtensions.OneCardOfEachColor);
 
             var play = player.FormulatePlay(board);
 
@@ -37,7 +27,7 @@ namespace GameEngineTests.Players
             var player = new GreatestDistanceSingleCardPlayer();
             var board = new GameBoard(2);
             board.Owls.Move(0, 6);
-            player.AddCardsToHand(OneCardOfEachColor);
+            player.AddCardsToHand(CardTypeExtensions.OneCardOfEachColor);
 
             var play = player.FormulatePlay(board);
 


### PR DESCRIPTION
This enhances and streamlines the options for initializing a game. Decks default to having more sun cards (to be more in line with the "real" game). The `OneCardOfEachColor` helper was moved and made public since it's now part of deck initialization.