### PR TITLE
Add support for multiple players

### DIFF
--- a/GameEngine/Agents/EpsilonGreedyAgent.cs
+++ b/GameEngine/Agents/EpsilonGreedyAgent.cs
@@ -23,7 +23,7 @@ namespace GameEngine.Agents
             }
 
             return new Play(
-                state.Hand.RandomCard,
+                state.CurrentPlayerHand.RandomCard,
                 state.Board.Owls.TrailingOwl
             );
         }

--- a/GameEngine/Agents/GreedyAgent.cs
+++ b/GameEngine/Agents/GreedyAgent.cs
@@ -7,7 +7,7 @@
             Play greatestSingleDistancePlay = null;
             int greatestDistance = 0;
             foreach (var owlPosition in state.Board.Owls.ListOfPositions) {
-                foreach (var card in state.Hand.Cards)
+                foreach (var card in state.CurrentPlayerHand.Cards)
                 {
                     var play = new Play(card, owlPosition);
                     var newPosition = state.Board.FindDestinationPosition(play);

--- a/GameEngine/Agents/LeastRecentCardAgent.cs
+++ b/GameEngine/Agents/LeastRecentCardAgent.cs
@@ -5,7 +5,7 @@
         public Play FormulatePlay(GameState state)
         {
             return new Play(
-                state.Hand.OldestCard,
+                state.CurrentPlayerHand.OldestCard,
                 state.Board.Owls.LeadOwl
             );
         }

--- a/GameEngine/Agents/RandomAgent.cs
+++ b/GameEngine/Agents/RandomAgent.cs
@@ -5,7 +5,7 @@
         public Play FormulatePlay(GameState state)
         {
             return new Play(
-                state.Hand.RandomCard,
+                state.CurrentPlayerHand.RandomCard,
                 state.Board.Owls.TrailingOwl
             );
         }

--- a/GameEngine/Agents/SearchNode.cs
+++ b/GameEngine/Agents/SearchNode.cs
@@ -18,11 +18,11 @@ namespace GameEngine.Agents
             {
                 return new SearchNode[] { };
             }
-            if (State.Hand.ContainsSun)
+            if (State.CurrentPlayerHand.ContainsSun)
             {
                 return new SearchNode[] { ChildNode(Play.Sun) };
             }
-            return State.Hand.Cards
+            return State.CurrentPlayerHand.Cards
                     .SelectMany(card => State.Board.Owls.ListOfPositions
                         .Select(owl => new Play(card, owl)))
                     .Select(ChildNode);

--- a/GameEngine/Game.cs
+++ b/GameEngine/Game.cs
@@ -1,4 +1,5 @@
-﻿using GameEngine.Agents;
+﻿using System.Collections.Generic;
+using GameEngine.Agents;
 
 namespace GameEngine
 {
@@ -21,7 +22,7 @@ namespace GameEngine
             {
                 Board = new GameBoard(options.ColoredSpacesPerColor, options.Owls),
                 Deck = deck,
-                Hand = new PlayerHand(deck.Draw(3)),
+                Hands = new List<PlayerHand> { new PlayerHand(deck.Draw(3)) } ,
                 SunSpaces = options.SunSpaces,
                 SunCounter = 0
             };
@@ -29,7 +30,7 @@ namespace GameEngine
 
         public void TakeTurn(IAgent player)
         {
-            var play = State.Hand.ContainsSun
+            var play = State.CurrentPlayerHand.ContainsSun
                 ? Play.Sun
                 : player.FormulatePlay(State);
             State = State.Successor(play);

--- a/GameEngine/Game.cs
+++ b/GameEngine/Game.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using GameEngine.Agents;
+﻿using GameEngine.Agents;
+using System.Linq;
 
 namespace GameEngine
 {
@@ -10,19 +10,19 @@ namespace GameEngine
         public bool IsWon { get { return State.IsWin; } }
         public bool IsLost { get { return State.IsLoss; } }
 
-        public Game(int multiplier)
+        public Game(int multiplier, int playerCount = 1)
         {
-            State = Start(GameOptions.FromMultiplier(multiplier));
+            State = Start(GameOptions.FromMultiplier(multiplier), playerCount);
         }
 
-        private GameState Start(GameOptions options)
+        private GameState Start(GameOptions options, int playerCount)
         {
             var deck = new DeterministicDeck(options.ColoredCardsPerColor, options.SunCards);
             return new GameState
             {
                 Board = new GameBoard(options.ColoredSpacesPerColor, options.Owls),
                 Deck = deck,
-                Hands = new List<PlayerHand> { new PlayerHand(deck.Draw(3)) } ,
+                Hands = Enumerable.Repeat(0, playerCount).Select( _ => new PlayerHand(deck.Draw(3)) ).ToList(),
                 SunSpaces = options.SunSpaces,
                 SunCounter = 0
             };

--- a/GameEngine/GameEngine.cs
+++ b/GameEngine/GameEngine.cs
@@ -7,9 +7,9 @@ namespace GameEngine
     {
         public void RunGame()
         {
-            var player = new LeastRecentCardAgent();
+            var player = new RandomAgent();
             int numberOfTurns = 0;
-            var game = new Game(10);
+            var game = new Game(4);
             while(!game.IsOver)
             {
                 game.TakeTurn(player);

--- a/GameEngine/GameEngine.cs
+++ b/GameEngine/GameEngine.cs
@@ -7,9 +7,9 @@ namespace GameEngine
     {
         public void RunGame()
         {
-            var player = new RandomAgent();
+            var player = new LeastRecentCardAgent();
             int numberOfTurns = 0;
-            var game = new Game(4);
+            var game = new Game(10);
             while(!game.IsOver)
             {
                 game.TakeTurn(player);

--- a/GameEngine/GameState.cs
+++ b/GameEngine/GameState.cs
@@ -103,14 +103,8 @@ namespace GameEngine
 
         private void NextPlayer()
         {
-            if (CurrentPlayer < Hands.Count - 1)
-            {
-                CurrentPlayer++;
-            }
-            else
-            {
-                CurrentPlayer = 0;
-            }
+            CurrentPlayer++;
+            CurrentPlayer %= Hands.Count;
         }
     }
 }

--- a/GameEngine/GameState.cs
+++ b/GameEngine/GameState.cs
@@ -55,12 +55,13 @@ namespace GameEngine
         {
             var other = o as GameState;
             return other != null
-                && Board.Equals(other.Board)
-                && Deck.Equals(other.Deck)
-                && Hands.Count == other.Hands.Count && Hands.Zip( other.Hands, (a,b) => a.Equals(b) ).All( b => b )
                 && SunSpaces == other.SunSpaces
                 && SunCounter == other.SunCounter
-                && CurrentPlayer == other.CurrentPlayer;
+                && Board.Equals(other.Board)
+                && Deck.Equals(other.Deck)
+                && CurrentPlayer == other.CurrentPlayer
+                && Hands.Count == other.Hands.Count
+                && Hands.Zip(other.Hands, (a, b) => a.Equals(b)).All(b => b);
         }
 
         public override int GetHashCode()

--- a/GameEngine/GameState.cs
+++ b/GameEngine/GameState.cs
@@ -11,10 +11,9 @@ namespace GameEngine
         public List<PlayerHand> Hands;
         public int SunSpaces;
         public int SunCounter;
+        public int CurrentPlayer = 0;
 
-        private int currentPlayer = 0;
-
-        public PlayerHand CurrentPlayerHand => Hands[currentPlayer];
+        public PlayerHand CurrentPlayerHand => Hands[CurrentPlayer];
 
         public bool IsOver
         {
@@ -47,7 +46,7 @@ namespace GameEngine
             state.CurrentPlayerHand.Discard(play.Card);
             state.CurrentPlayerHand.Add(state.Deck.Draw(1));
 
-            NextPlayer();
+            state.NextPlayer();
 
             return state;
         }
@@ -61,7 +60,7 @@ namespace GameEngine
                 && Hands.Count == other.Hands.Count && Hands.Zip( other.Hands, (a,b) => a.Equals(b) ).All( b => b )
                 && SunSpaces == other.SunSpaces
                 && SunCounter == other.SunCounter
-                && currentPlayer == other.currentPlayer;
+                && CurrentPlayer == other.CurrentPlayer;
         }
 
         public override int GetHashCode()
@@ -96,19 +95,20 @@ namespace GameEngine
                 Deck = Deck.Clone(),
                 Hands = Hands.Select( hand => hand.Clone() ).ToList(),
                 SunCounter = SunCounter,
-                SunSpaces = SunSpaces
+                SunSpaces = SunSpaces,
+                CurrentPlayer = CurrentPlayer,
             };
         }
 
         private void NextPlayer()
         {
-            if (currentPlayer < Hands.Count - 1)
+            if (CurrentPlayer < Hands.Count - 1)
             {
-                currentPlayer++;
+                CurrentPlayer++;
             }
             else
             {
-                currentPlayer = 0;
+                CurrentPlayer = 0;
             }
         }
     }

--- a/GameEngine/GameState.cs
+++ b/GameEngine/GameState.cs
@@ -8,7 +8,7 @@ namespace GameEngine
     {
         public GameBoard Board;
         public IDeck Deck;
-        public List<PlayerHand> Hands;
+        public IList<PlayerHand> Hands;
         public int SunSpaces;
         public int SunCounter;
         public int CurrentPlayer = 0;
@@ -71,7 +71,7 @@ namespace GameEngine
             {
                 hashCode = hashCode * -1521134295 + EqualityComparer<GameBoard>.Default.GetHashCode(Board);
                 hashCode = hashCode * -1521134295 + EqualityComparer<IDeck>.Default.GetHashCode(Deck);
-                hashCode = hashCode * -1521134295 + EqualityComparer<List<PlayerHand>>.Default.GetHashCode(Hands);
+                hashCode = hashCode * -1521134295 + EqualityComparer<IList<PlayerHand>>.Default.GetHashCode(Hands);
                 hashCode = hashCode * -1521134295 + SunSpaces.GetHashCode();
                 hashCode = hashCode * -1521134295 + SunCounter.GetHashCode();
             }

--- a/GameEngineTests/Agents/AStarAgentTests.cs
+++ b/GameEngineTests/Agents/AStarAgentTests.cs
@@ -30,8 +30,8 @@ namespace GameEngineTests.Agents
         public void ShouldThrowAnExceptionIfNoSolutionExists()
         {
             var state = TestUtilities.GenerateTestState(1, 1);
-            state.Hand.Cards.Clear();
-            state.Hand.Add(CardType.Sun);
+            state.CurrentPlayerHand.Cards.Clear();
+            state.CurrentPlayerHand.Add(CardType.Sun);
 
             // The only play is to play the sun card and lose.
             Assert.ThrowsException<NoSolutionFoundException>(() =>
@@ -43,8 +43,8 @@ namespace GameEngineTests.Agents
         public void ShouldThrowAnExceptionIfTheBoardStateDoesNotMatchPreviousPlay()
         {
             var state = TestUtilities.GenerateTestState(2, 1, 0);
-            state.Hand.Cards.Clear();
-            state.Hand.Cards.AddRange(CardTypeExtensions.OneCardOfEachColor);
+            state.CurrentPlayerHand.Cards.Clear();
+            state.CurrentPlayerHand.Cards.AddRange(CardTypeExtensions.OneCardOfEachColor);
 
             Agent.FormulatePlay(state);
             // Ignore what the agent said to play, and play something else instead.

--- a/GameEngineTests/Agents/BreadthFirstAgentTests.cs
+++ b/GameEngineTests/Agents/BreadthFirstAgentTests.cs
@@ -29,8 +29,8 @@ namespace GameEngineTests.Agents
         public void ShouldThrowAnExceptionIfNoSolutionExists()
         {
             var state = TestUtilities.GenerateTestState(1, 1);
-            state.Hand.Cards.Clear();
-            state.Hand.Add(CardType.Sun);
+            state.CurrentPlayerHand.Cards.Clear();
+            state.CurrentPlayerHand.Add(CardType.Sun);
 
             // The only play is to play the sun card and lose.
             Assert.ThrowsException<NoSolutionFoundException>(() =>
@@ -42,8 +42,8 @@ namespace GameEngineTests.Agents
         public void ShouldThrowAnExceptionIfTheBoardStateDoesNotMatchPreviousPlay()
         {
             var state = TestUtilities.GenerateTestState(2, 1, 0);
-            state.Hand.Cards.Clear();
-            state.Hand.Cards.AddRange(CardTypeExtensions.OneCardOfEachColor);
+            state.CurrentPlayerHand.Cards.Clear();
+            state.CurrentPlayerHand.Cards.AddRange(CardTypeExtensions.OneCardOfEachColor);
 
             Agent.FormulatePlay(state);
             // Ignore what the agent said to play, and play something else instead.

--- a/GameEngineTests/Agents/GreedyBestFirstAgentTests.cs
+++ b/GameEngineTests/Agents/GreedyBestFirstAgentTests.cs
@@ -30,8 +30,8 @@ namespace GameEngineTests.Agents
         public void ShouldThrowAnExceptionIfNoSolutionExists()
         {
             var state = TestUtilities.GenerateTestState(1, 1);
-            state.Hand.Cards.Clear();
-            state.Hand.Add(CardType.Sun);
+            state.CurrentPlayerHand.Cards.Clear();
+            state.CurrentPlayerHand.Add(CardType.Sun);
 
             // The only play is to play the sun card and lose.
             Assert.ThrowsException<NoSolutionFoundException>(() =>
@@ -43,8 +43,8 @@ namespace GameEngineTests.Agents
         public void ShouldThrowAnExceptionIfTheBoardStateDoesNotMatchPreviousPlay()
         {
             var state = TestUtilities.GenerateTestState(2, 1, 0);
-            state.Hand.Cards.Clear();
-            state.Hand.Cards.AddRange(CardTypeExtensions.OneCardOfEachColor);
+            state.CurrentPlayerHand.Cards.Clear();
+            state.CurrentPlayerHand.Cards.AddRange(CardTypeExtensions.OneCardOfEachColor);
 
             Agent.FormulatePlay(state);
             // Ignore what the agent said to play, and play something else instead.

--- a/GameEngineTests/Agents/LeastRecentCardAgentTests.cs
+++ b/GameEngineTests/Agents/LeastRecentCardAgentTests.cs
@@ -13,14 +13,14 @@ namespace GameEngineTests.Agents
             var state = TestUtilities.GenerateTestState(2);
             var firstCard = CardType.Red;
             var secondCard = CardType.Orange;
-            state.Hand.Cards.Clear();
-            state.Hand.Add(firstCard, secondCard);
+            state.CurrentPlayerHand.Cards.Clear();
+            state.CurrentPlayerHand.Add(firstCard, secondCard);
             var player = new LeastRecentCardAgent();
 
             var play = player.FormulatePlay(state);
             Assert.AreEqual(firstCard, play.Card);
 
-            state.Hand.Discard(play.Card);
+            state.CurrentPlayerHand.Discard(play.Card);
             play = player.FormulatePlay(state);
             Assert.AreEqual(secondCard, play.Card);
         }

--- a/GameEngineTests/Agents/RandomAgentTests.cs
+++ b/GameEngineTests/Agents/RandomAgentTests.cs
@@ -11,8 +11,8 @@ namespace GameEngineTests.Agents
         public void ShouldPlayRandomCardFromHand()
         {
             var state = TestUtilities.GenerateTestState(2);
-            state.Hand.Cards.Clear();
-            state.Hand.Add(CardType.Blue);
+            state.CurrentPlayerHand.Cards.Clear();
+            state.CurrentPlayerHand.Add(CardType.Blue);
             var player = new RandomAgent();
 
             var play = player.FormulatePlay(state);

--- a/GameEngineTests/GameStateTests.cs
+++ b/GameEngineTests/GameStateTests.cs
@@ -82,14 +82,17 @@ namespace GameEngineTests
         [TestMethod]
         public void ShouldUseNextPlayerHandAfterSuccessorIsCalled()
         {
-            var initialState = TestUtilities.GenerateTestState(playerCount: 2);
+            var initialState = TestUtilities.GenerateTestState(playerCount: 3);
             Assert.AreEqual(0, initialState.CurrentPlayer);
 
             var nextState1 = initialState.Successor(Play.Sun);
             Assert.AreEqual(1, nextState1.CurrentPlayer);
 
             var nextState2 = nextState1.Successor(Play.Sun);
-            Assert.AreEqual(0, nextState2.CurrentPlayer);
+            Assert.AreEqual(2, nextState2.CurrentPlayer);
+
+            var nextState3 = nextState2.Successor(Play.Sun);
+            Assert.AreEqual(0, nextState3.CurrentPlayer);
         }
     }
 }

--- a/GameEngineTests/GameStateTests.cs
+++ b/GameEngineTests/GameStateTests.cs
@@ -1,5 +1,6 @@
 ﻿using GameEngine;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
 
 namespace GameEngineTests
 {
@@ -15,7 +16,7 @@ namespace GameEngineTests
             Assert.AreNotSame(initialState, clonedState);
             Assert.AreEqual(initialState.Board, clonedState.Board);
             Assert.AreEqual(initialState.Deck, clonedState.Deck);
-            CollectionAssert.AreEqual(initialState.Hands, clonedState.Hands);
+            CollectionAssert.AreEqual(initialState.Hands.ToArray(), clonedState.Hands.ToArray());
             Assert.AreEqual(initialState.SunSpaces, clonedState.SunSpaces);
             Assert.AreEqual(initialState.SunCounter, clonedState.SunCounter);
             Assert.AreEqual(initialState.CurrentPlayer, clonedState.CurrentPlayer);

--- a/GameEngineTests/GameStateTests.cs
+++ b/GameEngineTests/GameStateTests.cs
@@ -15,7 +15,7 @@ namespace GameEngineTests
             Assert.AreNotSame(initialState, clonedState);
             Assert.AreEqual(initialState.Board, clonedState.Board);
             Assert.AreEqual(initialState.Deck, clonedState.Deck);
-            Assert.AreEqual(initialState.Hand, clonedState.Hand);
+            CollectionAssert.AreEqual(initialState.Hands, clonedState.Hands);
             Assert.AreEqual(initialState.SunSpaces, clonedState.SunSpaces);
             Assert.AreEqual(initialState.SunCounter, clonedState.SunCounter);
             Assert.AreEqual(initialState, clonedState);
@@ -49,9 +49,9 @@ namespace GameEngineTests
             var initialState = TestUtilities.GenerateTestState();
             var nextState = initialState.Clone();
 
-            nextState.Hand.Discard(initialState.Hand.Cards[0]);
+            nextState.CurrentPlayerHand.Discard(initialState.CurrentPlayerHand.Cards[0]);
 
-            Assert.AreNotEqual(initialState.Hand, nextState.Hand);
+            Assert.AreNotEqual(initialState.Hands, nextState.Hands);
             Assert.AreNotEqual(initialState, nextState);
         }
 

--- a/GameEngineTests/GameStateTests.cs
+++ b/GameEngineTests/GameStateTests.cs
@@ -76,5 +76,18 @@ namespace GameEngineTests
             Assert.AreNotEqual(initialState.SunCounter, nextState.SunCounter);
             Assert.AreNotEqual(initialState, nextState);
         }
+
+        [TestMethod]
+        public void ShouldUseNextPlayerHandAfterSuccessorIsCalled()
+        {
+            var initialState = TestUtilities.GenerateTestState(playerCount: 2);
+            Assert.AreEqual(0, initialState.CurrentPlayer);
+
+            var nextState1 = initialState.Successor(Play.Sun);
+            Assert.AreEqual(1, nextState1.CurrentPlayer);
+
+            var nextState2 = nextState1.Successor(Play.Sun);
+            Assert.AreEqual(0, nextState2.CurrentPlayer);
+        }
     }
 }

--- a/GameEngineTests/GameStateTests.cs
+++ b/GameEngineTests/GameStateTests.cs
@@ -18,6 +18,7 @@ namespace GameEngineTests
             CollectionAssert.AreEqual(initialState.Hands, clonedState.Hands);
             Assert.AreEqual(initialState.SunSpaces, clonedState.SunSpaces);
             Assert.AreEqual(initialState.SunCounter, clonedState.SunCounter);
+            Assert.AreEqual(initialState.CurrentPlayer, clonedState.CurrentPlayer);
             Assert.AreEqual(initialState, clonedState);
         }
 

--- a/GameEngineTests/GameTests.cs
+++ b/GameEngineTests/GameTests.cs
@@ -16,7 +16,7 @@ namespace GameEngineTests
         private Game Game;
         private GameBoard Board { get { return Game.State.Board; } }
         private DeterministicDeck Deck { get { return Game.State.Deck as DeterministicDeck; } }
-        private PlayerHand Hand { get { return Game.State.Hand; } }
+        private PlayerHand Hand { get { return Game.State.CurrentPlayerHand; } }
         private int SunCounter { get { return Game.State.SunCounter; } }
 
         [TestInitialize]

--- a/GameEngineTests/TestUtilities.cs
+++ b/GameEngineTests/TestUtilities.cs
@@ -1,6 +1,5 @@
 ﻿using GameEngine;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Collections.Generic;
 using System.Linq;
 
 namespace GameEngineTests
@@ -10,7 +9,8 @@ namespace GameEngineTests
         public static GameState GenerateTestState(
             int multiplier = 6,
             int? numberOfOwls = null,
-            int? numberOfSunCards = null)
+            int? numberOfSunCards = null,
+            int playerCount = 1)
         {
             var board = numberOfOwls.HasValue
                 ? new GameBoard(multiplier, numberOfOwls.Value)
@@ -19,7 +19,7 @@ namespace GameEngineTests
             {
                 Board = board,
                 Deck = new DeterministicDeck(multiplier, numberOfSunCards),
-                Hands = new List<PlayerHand> { new PlayerHand(CardTypeExtensions.OneCardOfEachColor) },
+                Hands = Enumerable.Repeat(0, playerCount).Select( _ => new PlayerHand(CardTypeExtensions.OneCardOfEachColor) ).ToList(),
                 SunCounter = 0,
                 SunSpaces = multiplier
             };

--- a/GameEngineTests/TestUtilities.cs
+++ b/GameEngineTests/TestUtilities.cs
@@ -1,5 +1,6 @@
 ﻿using GameEngine;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace GameEngineTests
@@ -18,7 +19,7 @@ namespace GameEngineTests
             {
                 Board = board,
                 Deck = new DeterministicDeck(multiplier, numberOfSunCards),
-                Hand = new PlayerHand(CardTypeExtensions.OneCardOfEachColor),
+                Hands = new List<PlayerHand> { new PlayerHand(CardTypeExtensions.OneCardOfEachColor) },
                 SunCounter = 0,
                 SunSpaces = multiplier
             };


### PR DESCRIPTION
The GameState class now has a CurrentPlayerHand property.  As the Successor method is called new CurrentPlayers are returned from the property.

Agents now look at the CurrentPlayerHand property instead of the Hand field.

Game has the option (defaulting to 1) to select how many players the game will have.